### PR TITLE
fix: 使用docker-compose不能正常运行镜像

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ git clone https://github.com/Xavier9896/node-hiprint-transit.git
 cd node-hiprint-transit
 ```
 
-### 2. 启动服务
+### 2. 修改 `docker-compose.yml` 文件
+
+修改文件中 `/to/your/config.json/path/config.json` 和 `/to/your/log/path` 挂载到正确的 `config.json` 设置文件和 `logs` 日志存储文件夹路径。
+
+### 3. 启动服务
 
 ```bash
 docker-compose up -d

--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ cd node-hiprint-transit
 
 ### 2. 修改 `docker-compose.yml` 文件
 
-修改文件中 `/to/your/config.json/path/config.json` 和 `/to/your/log/path` 挂载到正确的 `config.json` 设置文件和 `logs` 日志存储文件夹路径。
+修改文件中 `/path/to/your/config.json` 和 `/path/to/your/logs` 挂载到正确的 `config.json` 设置文件和 `logs` 日志存储文件夹路径。
+
+> [!NOTE]
+> 在运行 `docker-compose up -d` 之前，请确保您已经在宿主机上创建了 `config.json` 文件和 `logs` 目录。您可以从项目根目录复制 `config.json` 作为模板。
 
 ### 3. 启动服务
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     ports:
       - "17521:17521"
     volumes:
-      - /to/your/config.json/path/config.json:/node-hiprint-transit/config.json
-      - /to/your/log/path/:/node-hiprint-transit/logs
+      - /path/to/your/config.json:/node-hiprint-transit/config.json
+      - /path/to/your/logs:/node-hiprint-transit/logs
       # 以下两项为可选项，不需配置SSL时可删除
       # - /to/your/ssl.key/path/ssl.key:/node-hiprint-transit/src/ssl.key
       # - /to/your/ssl.pem/path/ssl.pem:/node-hiprint-transit/src/ssl.pem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,16 @@ version: '3.8'
 
 services:
   node-hiprint-transit:
+    container_name: "node-hiprint-transit"
     build: .
     ports:
       - "17521:17521"
     volumes:
-      - .:/node-hiprint-transit
+      - /to/your/config.json/path/config.json:/node-hiprint-transit/config.json
+      - /to/your/log/path/:/node-hiprint-transit/logs
+      # 以下两项为可选项，不需配置SSL时可删除
+      # - /to/your/ssl.key/path/ssl.key:/node-hiprint-transit/src/ssl.key
+      # - /to/your/ssl.pem/path/ssl.pem:/node-hiprint-transit/src/ssl.pem
     environment:
+      TZ: Asia/Shanghai
       NODE_ENV: production


### PR DESCRIPTION
修复 docker-compose 中错误的挂载项目目录导致不能正常运行镜像https://github.com/Xavier9896/node-hiprint-transit/issues/8